### PR TITLE
Use laz-rs as LAZ backend again

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,11 +8,6 @@ dependencies:
   - numpy
   - scipy
   - laspy>=2.0
-  # There are currently no conda-forge packages for the Python bindings of
-  # either laz-rs or LASzip, so get them with pip
-  - pip
-  - pip:
-    # Consider replacing with lazrs if it is deemed sufficiently reliable
-    - laszip
+  - lazrs-python
   # For testing only
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - scipy
   - laspy>=2.0
+  # Consider reverting to pip + pip-installed laszip in case of problems
   - lazrs-python
   # For testing only
   - pytest


### PR DESCRIPTION
laz-rs now has a proper conda-forge package, and hopefully some bugfixes since last time.