### PR TITLE
Better refactor of create_local_datasource()

### DIFF
--- a/qc/db/report.py
+++ b/qc/db/report.py
@@ -432,9 +432,14 @@ def create_local_datasource(name=None, overwrite=False):
     if overwrite:
         drv.DeleteDataSource(name)
         data_source = None
-
-    print("Creating local data source for reporting.")
-    data_source = drv.CreateDataSource(name, FALL_BACK_DSCO)
+    else:
+        try:
+            data_source = ogr.Open(name, True)
+        except RuntimeError:
+            data_source = None
+    if data_source is None:
+        print("Creating local data source for reporting.")
+        data_source = drv.CreateDataSource(name, FALL_BACK_DSCO)
     create_layers(data_source, None)
     return data_source
 


### PR DESCRIPTION
The changes in #60 caused some behavior to change when the datasource exists and `overwrite` is `False`. Properly restore previous behavior.